### PR TITLE
Improve default width of sidemenu

### DIFF
--- a/src/main/kotlin/app/ui/RepositoryOpen.kt
+++ b/src/main/kotlin/app/ui/RepositoryOpen.kt
@@ -117,7 +117,7 @@ fun MainContentView(
 ) {
     Row {
         HorizontalSplitPane {
-            first(minSize = 200.dp) {
+            first(minSize = 350.dp) {
                 Column(
                     modifier = Modifier
                         .widthIn(min = 300.dp)


### PR DESCRIPTION
The default width of the sidemenu is too low and does not even fit its own header text. It has been increased to provide a better visual experience.

Before:
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/593870/171294790-8e59cdb7-d214-435f-8791-022fed956b6d.png">

After:
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/593870/171294833-d1a142a1-0546-440e-9ac5-2f41b394bdb8.png">
