### PR TITLE
Allow macOS to use CMD+R to refresh repositories

### DIFF
--- a/src/main/kotlin/app/ui/RepositoryOpen.kt
+++ b/src/main/kotlin/app/ui/RepositoryOpen.kt
@@ -14,10 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
@@ -98,7 +95,9 @@ fun RepositoryOpenPage(tabViewModel: TabViewModel) {
             .focusRequester(focusRequester)
             .focusable()
             .onKeyEvent { event ->
-                if (event.key == Key.F5) {
+                val os = System.getProperty("os.name")
+                val ismacOS = os.lowercase() == "mac os x"
+                if (event.key == Key.F5 || (ismacOS && event.isMetaPressed && event.key == Key.R)) {
                     tabViewModel.refreshAll()
                     true
                 } else {


### PR DESCRIPTION
On macOS it is pretty common to use Command + R to refresh views as opposed to F5. This change does not remove the ability to use F5 but it adds a case for if the platform is macOS to use Command + R instead.