### PR TITLE
Add key to the StatusEntries list

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/UncommitedChanges.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/UncommitedChanges.kt
@@ -581,7 +581,7 @@ private fun EntriesList(
                 .background(MaterialTheme.colors.background),
             state = lazyListState,
         ) {
-            items(statusEntries) { statusEntry ->
+            items(statusEntries, key = { it.filePath }) { statusEntry ->
                 val isEntrySelected = selectedEntryType != null &&
                         selectedEntryType is DiffEntryType.UncommitedDiff && // Added for smartcast
                         selectedEntryType.statusEntry == statusEntry


### PR DESCRIPTION
When clicking around a lot, staging and unstaging some files, it otherwise messed up the association of StatusEntry and file and then didn't do anything when I clicked a certain file, presumably because it thought it was already shown.