### PR TITLE
Fix libssh loading on Linux

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/ssh/libssh/LibSshWrapper.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ssh/libssh/LibSshWrapper.kt
@@ -43,9 +43,6 @@ interface SSHLibrary : Library {
 
 
     companion object {
-        val INSTANCE = Native.loadLibrary(
-            if (getCurrentOs().isWindows()) "ssh" else "libssh",
-            SSHLibrary::class.java
-        ) as SSHLibrary
+        val INSTANCE = Native.loadLibrary("ssh", SSHLibrary::class.java) as SSHLibrary
     }
 }


### PR DESCRIPTION
The file is called `libssh.so`, but JNA already prefixes the `lib` part, so `Native.loadLibrary("ssh", ...)` results in an `liblibssh.so not found` error.