### PR TITLE
Allow customizing the window title with an environment variable

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/App.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/App.kt
@@ -100,7 +100,7 @@ class App {
 
             if (isOpen) {
                 Window(
-                    title = AppConstants.APP_NAME,
+                    title = System.getenv("title") ?: AppConstants.APP_NAME,
                     onCloseRequest = {
                         isOpen = false
                     },


### PR DESCRIPTION
This allows me to configure `title=GitnuroDEV` in my IDE's run config for the app, to distinguish the dev version that I'm running to test it from the prod version I'm running to stage/commit stuff.