### PR TITLE
Feature/issue 73 squash from graph view

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/git/TaskEvent.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/git/TaskEvent.kt
@@ -5,5 +5,6 @@ import org.eclipse.jgit.revwalk.RevCommit
 
 sealed interface TaskEvent {
     data class RebaseInteractive(val revCommit: RevCommit) : TaskEvent
+    data class SquashCommits(val commits: List<RevCommit>, val upstreamCommit: RevCommit) : TaskEvent
     data class ScrollToGraphItem(val selectedItem: SelectedItem) : TaskEvent
 }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/git/branches/GetBranchByCommitUseCase.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/git/branches/GetBranchByCommitUseCase.kt
@@ -1,0 +1,25 @@
+package com.jetpackduba.gitnuro.git.branches
+
+import com.jetpackduba.gitnuro.extensions.isBranch
+import com.jetpackduba.gitnuro.extensions.isHead
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ListBranchCommand
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.revwalk.RevCommit
+import javax.inject.Inject
+
+class GetBranchByCommitUseCase @Inject constructor() {
+
+    suspend operator fun invoke(git: Git, commit: RevCommit): Ref = withContext(Dispatchers.IO) {
+        git
+            .branchList()
+            .setContains(commit.id.name)
+            .setListMode(ListBranchCommand.ListMode.ALL)
+            .call()
+            .first { it.isBranch }
+    }
+
+}

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/RepositoryOpen.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/RepositoryOpen.kt
@@ -127,9 +127,12 @@ fun RepositoryOpenPage(
                     }
             ) {
                 val rebaseInteractiveViewModel = tabViewModel.rebaseInteractiveViewModel
+                val squashCommitsViewModel = tabViewModel.squashCommitsViewModel
 
                 if (repositoryState == RepositoryState.REBASING_INTERACTIVE && rebaseInteractiveViewModel != null) {
                     RebaseInteractive(rebaseInteractiveViewModel)
+                } else if (repositoryState == RepositoryState.REBASING_INTERACTIVE && squashCommitsViewModel != null) {
+                    SquashCommits(squashCommitsViewModel)
                 } else if (repositoryState == RepositoryState.REBASING_INTERACTIVE) {
                     RebaseInteractiveStartedExternally(
                         onCancelRebaseInteractive = { tabViewModel.cancelRebaseInteractive() }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/SquashCommits.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/SquashCommits.kt
@@ -1,0 +1,101 @@
+package com.jetpackduba.gitnuro.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.jetpackduba.gitnuro.ui.components.AdjustableOutlinedTextField
+import com.jetpackduba.gitnuro.ui.components.PrimaryButton
+import com.jetpackduba.gitnuro.viewmodels.SquashCommitsState
+import com.jetpackduba.gitnuro.viewmodels.SquashCommitsViewModel
+
+@Composable
+fun SquashCommits(
+    squashCommitsViewModel: SquashCommitsViewModel
+) {
+    val state = squashCommitsViewModel.squashState.collectAsState()
+    val stateValue = state.value
+
+    Box(
+        modifier = Modifier
+            .background(MaterialTheme.colors.surface)
+            .fillMaxSize(),
+    ) {
+        when (stateValue) {
+            is SquashCommitsState.Failed -> {}
+            is SquashCommitsState.Loaded -> {
+                SquashCommitsLoaded(
+                    squashCommitsViewModel,
+                    stateValue,
+                )
+            }
+
+            SquashCommitsState.Loading -> {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SquashCommitsLoaded(
+    viewModel: SquashCommitsViewModel,
+    stateValue: SquashCommitsState.Loaded,
+) {
+    Column {
+        Text(
+            text = "Edit message for squashed commits",
+            color = MaterialTheme.colors.onBackground,
+            modifier = Modifier.padding(start = 16.dp, top = 16.dp),
+            fontSize = 20.sp,
+        )
+
+        Column(
+            modifier = Modifier
+                .weight(1f)
+        ) {
+            AdjustableOutlinedTextField(
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(min = 40.dp),
+                value = stateValue.message,
+                onValueChange = {
+                    viewModel.editMessage(it)
+                },
+                textStyle = MaterialTheme.typography.body2,
+                backgroundColor = MaterialTheme.colors.background
+            )
+        }
+
+        Row(
+            modifier = Modifier.padding(bottom = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+            PrimaryButton(
+                text = "Cancel",
+                modifier = Modifier.padding(end = 8.dp),
+                onClick = {
+                    viewModel.cancel()
+                },
+                backgroundColor = Color.Transparent,
+                textColor = MaterialTheme.colors.onBackground,
+            )
+            PrimaryButton(
+                modifier = Modifier.padding(end = 16.dp),
+                onClick = {
+                    viewModel.continueSquash()
+                },
+                text = "OK"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/CommitChanges.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/CommitChanges.kt
@@ -1,4 +1,4 @@
-package com.jetpackduba.gitnuro.ui
+package com.jetpackduba.gitnuro.ui.changes
 
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
@@ -19,12 +19,14 @@ import androidx.compose.ui.unit.dp
 import com.jetpackduba.gitnuro.extensions.*
 import com.jetpackduba.gitnuro.git.DiffEntryType
 import com.jetpackduba.gitnuro.theme.*
+import com.jetpackduba.gitnuro.ui.SelectedItem
 import com.jetpackduba.gitnuro.ui.components.AvatarImage
 import com.jetpackduba.gitnuro.ui.components.ScrollableLazyColumn
 import com.jetpackduba.gitnuro.ui.components.TooltipText
 import com.jetpackduba.gitnuro.ui.components.gitnuroViewModel
 import com.jetpackduba.gitnuro.ui.context_menu.ContextMenu
 import com.jetpackduba.gitnuro.ui.context_menu.commitedChangesEntriesContextMenuItems
+import com.jetpackduba.gitnuro.viewmodels.CommitChanges
 import com.jetpackduba.gitnuro.viewmodels.CommitChangesStatus
 import com.jetpackduba.gitnuro.viewmodels.CommitChangesViewModel
 import kotlinx.coroutines.delay
@@ -253,65 +255,77 @@ fun CommitLogChanges(
                     )
                 }
             ) {
-                Column(
-                    modifier = Modifier
-                        .height(40.dp)
-                        .fillMaxWidth()
-                        .handMouseClickable {
-                            onDiffSelected(diffEntry)
-                        }
-                        .backgroundIf(
-                            condition = diffSelected is DiffEntryType.CommitDiff && diffSelected.diffEntry == diffEntry,
-                            color = MaterialTheme.colors.backgroundSelected,
-                        ),
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Spacer(modifier = Modifier.weight(2f))
-
-                    Row {
-                        Icon(
-                            modifier = Modifier
-                                .padding(horizontal = 8.dp)
-                                .size(16.dp),
-                            imageVector = diffEntry.icon,
-                            contentDescription = null,
-                            tint = diffEntry.iconColor,
-                        )
-
-                        if (diffEntry.parentDirectoryPath.isNotEmpty()) {
-                            Text(
-                                text = diffEntry.parentDirectoryPath.removeSuffix("/"),
-                                modifier = Modifier.weight(1f, fill = false),
-                                maxLines = 1,
-                                softWrap = false,
-                                overflow = TextOverflow.Ellipsis,
-                                style = MaterialTheme.typography.body2,
-                                color = MaterialTheme.colors.onBackgroundSecondary,
-                            )
-
-                            Text(
-                                text = "/",
-                                maxLines = 1,
-                                softWrap = false,
-                                style = MaterialTheme.typography.body2,
-                                overflow = TextOverflow.Visible,
-                                color = MaterialTheme.colors.onBackgroundSecondary,
-                            )
-                        }
-                        Text(
-                            text = diffEntry.fileName,
-                            maxLines = 1,
-                            softWrap = false,
-                            modifier = Modifier.padding(end = 16.dp),
-                            style = MaterialTheme.typography.body2,
-                            color = MaterialTheme.colors.onBackground,
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.weight(2f))
-
-                }
+                CommitLogChangesItem(
+                    diffEntry = diffEntry,
+                    diffSelected = diffSelected,
+                    onDiffSelected = { onDiffSelected(diffEntry) }
+                )
             }
         }
+    }
+}
+
+@Composable
+fun CommitLogChangesItem(
+    diffEntry: DiffEntry,
+    diffSelected: DiffEntryType?,
+    onDiffSelected: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .height(40.dp)
+            .fillMaxWidth()
+            .handMouseClickable {
+                onDiffSelected()
+            }
+            .backgroundIf(
+                condition = diffSelected is DiffEntryType.CommitDiff && diffSelected.diffEntry == diffEntry,
+                color = MaterialTheme.colors.backgroundSelected,
+            ),
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Spacer(modifier = Modifier.weight(2f))
+
+        Row {
+            Icon(
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .size(16.dp),
+                imageVector = diffEntry.icon,
+                contentDescription = null,
+                tint = diffEntry.iconColor,
+            )
+
+            if (diffEntry.parentDirectoryPath.isNotEmpty()) {
+                Text(
+                    text = diffEntry.parentDirectoryPath.removeSuffix("/"),
+                    modifier = Modifier.weight(1f, fill = false),
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.body2,
+                    color = MaterialTheme.colors.onBackgroundSecondary,
+                )
+
+                Text(
+                    text = "/",
+                    maxLines = 1,
+                    softWrap = false,
+                    style = MaterialTheme.typography.body2,
+                    overflow = TextOverflow.Visible,
+                    color = MaterialTheme.colors.onBackgroundSecondary,
+                )
+            }
+            Text(
+                text = diffEntry.fileName,
+                maxLines = 1,
+                softWrap = false,
+                modifier = Modifier.padding(end = 16.dp),
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onBackground,
+            )
+        }
+
+        Spacer(modifier = Modifier.weight(2f))
     }
 }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/MultiCommitChanges.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/MultiCommitChanges.kt
@@ -1,0 +1,137 @@
+package com.jetpackduba.gitnuro.ui.changes
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Divider
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.jetpackduba.gitnuro.git.DiffEntryType
+import com.jetpackduba.gitnuro.theme.tertiarySurface
+import com.jetpackduba.gitnuro.ui.SelectedItem
+import com.jetpackduba.gitnuro.ui.components.ScrollableColumn
+import com.jetpackduba.gitnuro.ui.components.ScrollableLazyColumn
+import com.jetpackduba.gitnuro.ui.components.gitnuroViewModel
+import com.jetpackduba.gitnuro.viewmodels.CommitChanges
+import com.jetpackduba.gitnuro.viewmodels.MultiCommitChangesStatus
+import com.jetpackduba.gitnuro.viewmodels.MultiCommitChangesViewModel
+import org.eclipse.jgit.diff.DiffEntry
+import org.eclipse.jgit.revwalk.RevCommit
+
+
+@Composable
+fun MultiCommitChanges(
+    multiCommitChangesViewModel: MultiCommitChangesViewModel = gitnuroViewModel(),
+    selectedItem: SelectedItem.MultiCommitBasedItem,
+    onDiffSelected: (DiffEntry) -> Unit,
+    diffSelected: DiffEntryType?,
+    onBlame: (String) -> Unit,
+    onHistory: (String) -> Unit,
+) {
+    LaunchedEffect(selectedItem) {
+        multiCommitChangesViewModel.loadChanges(selectedItem.itemList)
+    }
+
+    val commitChangesStatusState = multiCommitChangesViewModel.commitsChangesStatus.collectAsState()
+
+    when (val commitChangesStatus = commitChangesStatusState.value) {
+        MultiCommitChangesStatus.Loading -> {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth(), color = MaterialTheme.colors.primaryVariant)
+        }
+
+        is MultiCommitChangesStatus.Loaded -> {
+            MultiCommitChangesView(
+                diffSelected = diffSelected,
+                changes = commitChangesStatus.changesList,
+                onDiffSelected = onDiffSelected,
+                onBlame = onBlame,
+                onHistory = onHistory,
+            )
+        }
+    }
+}
+
+@Composable
+fun MultiCommitChangesView(
+    changes: List<CommitChanges>,
+    onDiffSelected: (DiffEntry) -> Unit,
+    diffSelected: DiffEntryType?,
+    onBlame: (String) -> Unit,
+    onHistory: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .padding(end = 8.dp, bottom = 8.dp)
+            .fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(bottom = 4.dp)
+                .fillMaxWidth()
+                .weight(1f, fill = true)
+                .background(MaterialTheme.colors.background)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(34.dp)
+                    .background(MaterialTheme.colors.tertiarySurface),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                Text(
+                    modifier = Modifier
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    text = "Files changed",
+                    fontWeight = FontWeight.Normal,
+                    textAlign = TextAlign.Left,
+                    color = MaterialTheme.colors.onBackground,
+                    maxLines = 1,
+                    style = MaterialTheme.typography.body2,
+                )
+            }
+
+            ScrollableLazyColumn(
+                modifier = Modifier
+            ) {
+                items(changes) {commitChanges ->
+                    CommitLogChanges(
+                        diffSelected = diffSelected,
+                        diffEntries = commitChanges.changes,
+                        onDiffSelected = onDiffSelected,
+                        onBlame = onBlame,
+                        onHistory = onHistory,
+                    )
+
+                    Text(
+                        text = commitChanges.commit.fullMessage,
+                        style = MaterialTheme.typography.body1,
+                        color = MaterialTheme.colors.onBackground,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp),
+                    )
+
+                    Divider(
+                        color = MaterialTheme.colors.onBackground,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/MultiCommitChanges.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/MultiCommitChanges.kt
@@ -21,12 +21,15 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.jetpackduba.gitnuro.extensions.filePath
 import com.jetpackduba.gitnuro.git.DiffEntryType
 import com.jetpackduba.gitnuro.theme.tertiarySurface
 import com.jetpackduba.gitnuro.ui.SelectedItem
 import com.jetpackduba.gitnuro.ui.components.ScrollableColumn
 import com.jetpackduba.gitnuro.ui.components.ScrollableLazyColumn
 import com.jetpackduba.gitnuro.ui.components.gitnuroViewModel
+import com.jetpackduba.gitnuro.ui.context_menu.ContextMenu
+import com.jetpackduba.gitnuro.ui.context_menu.commitedChangesEntriesContextMenuItems
 import com.jetpackduba.gitnuro.viewmodels.CommitChanges
 import com.jetpackduba.gitnuro.viewmodels.MultiCommitChangesStatus
 import com.jetpackduba.gitnuro.viewmodels.MultiCommitChangesViewModel
@@ -108,28 +111,49 @@ fun MultiCommitChangesView(
             ScrollableLazyColumn(
                 modifier = Modifier
             ) {
-                items(changes) {commitChanges ->
-                    CommitLogChanges(
-                        diffSelected = diffSelected,
-                        diffEntries = commitChanges.changes,
-                        onDiffSelected = onDiffSelected,
-                        onBlame = onBlame,
-                        onHistory = onHistory,
-                    )
+                changes.forEach { commitChanges ->
+                    items(commitChanges.changes) { diffEntry ->
+                        ContextMenu(
+                            items = {
+                                commitedChangesEntriesContextMenuItems(
+                                    diffEntry,
+                                    onBlame = { onBlame(diffEntry.filePath) },
+                                    onHistory = { onHistory(diffEntry.filePath) },
+                                )
+                            }
+                        ) {
+                            CommitLogChangesItem(
+                                diffEntry = diffEntry,
+                                diffSelected = diffSelected,
+                                onDiffSelected = { onDiffSelected(diffEntry) }
+                            )
+                        }
+                    }
 
-                    Text(
-                        text = commitChanges.commit.fullMessage,
-                        style = MaterialTheme.typography.body1,
-                        color = MaterialTheme.colors.onBackground,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp),
-                    )
+                    item {
+                        Column (
+                            modifier = Modifier
+                                .padding(top = 8.dp)
+                        ) {
+                            Text(
+                                text = commitChanges.commit.fullMessage,
+                                style = MaterialTheme.typography.body1,
+                                color = MaterialTheme.colors.onBackground,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(
+                                        horizontal = 8.dp,
+                                    ),
+                            )
 
-                    Divider(
-                        color = MaterialTheme.colors.onBackground,
-                        modifier = Modifier.fillMaxWidth()
-                    )
+                            Author(id = commitChanges.commit.id, author = commitChanges.commit.authorIdent)
+
+                            Divider(
+                                color = MaterialTheme.colors.onBackground,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/UncommitedChanges.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/changes/UncommitedChanges.kt
@@ -1,6 +1,6 @@
 @file:OptIn(ExperimentalAnimationApi::class, ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 
-package com.jetpackduba.gitnuro.ui
+package com.jetpackduba.gitnuro.ui.changes
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/context_menu/ContextMenu.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/context_menu/ContextMenu.kt
@@ -140,7 +140,11 @@ fun showPopup(x: Int, y: Int, contextMenuElements: List<ContextMenuElement>, onD
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 for (item in contextMenuElements) {
                     when (item) {
-                        is ContextMenuElement.ContextTextEntry -> TextEntry(item, onDismissRequest = onDismissRequest)
+                        is ContextMenuElement.ContextTextEntry -> {
+                            if (item.isVisible) {
+                                TextEntry(item, onDismissRequest = onDismissRequest)
+                            }
+                        }
                         ContextMenuElement.ContextSeparator -> Separator()
                     }
 
@@ -203,7 +207,8 @@ sealed interface ContextMenuElement {
     data class ContextTextEntry(
         val label: String,
         val icon: @Composable (() -> Painter)? = null,
-        val onClick: () -> Unit = {}
+        val onClick: () -> Unit = {},
+        val isVisible: Boolean = true,
     ) : ContextMenuElement
 
     object ContextSeparator : ContextMenuElement

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/context_menu/LogContextMenu.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/context_menu/LogContextMenu.kt
@@ -10,11 +10,19 @@ fun logContextMenu(
     onCherryPickCommit: () -> Unit,
     onResetBranch: () -> Unit,
     onRebaseInteractive: () -> Unit,
+    showSquashCommits: Boolean,
+    onSquashCommits: () -> Unit,
 ) = listOf(
     ContextMenuElement.ContextTextEntry(
         label = "Checkout commit",
         icon = { painterResource("start.svg") },
         onClick = onCheckoutCommit
+    ),
+    ContextMenuElement.ContextTextEntry(
+        label = "Squash commits",
+        icon = { painterResource("branch.svg") },
+        isVisible = showSquashCommits,
+        onClick = onSquashCommits
     ),
     ContextMenuElement.ContextTextEntry(
         label = "Create branch",

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/log/Log.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/log/Log.kt
@@ -429,6 +429,8 @@ fun MessagesList(
                 onRevCommitSelected = {
                     logViewModel.selectLogLine(graphNode, keyScope.isCtrlPressed, keyScope.isShiftPressed)
                 },
+                onSquashCommits = { logViewModel.squashCommits() },
+                showSquashCommits = selectedItem is SelectedItem.MultiCommitBasedItem && selectedItem.itemList.size > 1
             )
         }
 
@@ -764,6 +766,8 @@ fun CommitLine(
     onRebaseBranch: (Ref) -> Unit,
     onRevCommitSelected: () -> Unit,
     onRebaseInteractive: () -> Unit,
+    onSquashCommits: () -> Unit,
+    showSquashCommits: Boolean,
 ) {
     ContextMenu(
         items = {
@@ -775,6 +779,8 @@ fun CommitLine(
                 onCherryPickCommit = { logViewModel.cherrypickCommit(graphNode) },
                 onRebaseInteractive = onRebaseInteractive,
                 onResetBranch = { resetBranch() },
+                onSquashCommits = { onSquashCommits() },
+                showSquashCommits = showSquashCommits,
             )
         },
     ) {

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/MultiCommitChangesViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/MultiCommitChangesViewModel.kt
@@ -1,0 +1,52 @@
+package com.jetpackduba.gitnuro.viewmodels
+
+import com.jetpackduba.gitnuro.extensions.delayedStateChange
+import com.jetpackduba.gitnuro.extensions.filePath
+import com.jetpackduba.gitnuro.git.RefreshType
+import com.jetpackduba.gitnuro.git.TabState
+import com.jetpackduba.gitnuro.git.diff.GetCommitDiffEntriesUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.eclipse.jgit.diff.DiffEntry
+import org.eclipse.jgit.revwalk.DepthWalk.Commit
+import org.eclipse.jgit.revwalk.RevCommit
+import javax.inject.Inject
+
+private const val MIN_TIME_IN_MS_TO_SHOW_LOAD = 300L
+
+class MultiCommitChangesViewModel @Inject constructor(
+    private val tabState: TabState,
+    private val getCommitDiffEntriesUseCase: GetCommitDiffEntriesUseCase,
+) {
+    private val _commitsChangesStatus = MutableStateFlow<MultiCommitChangesStatus>(MultiCommitChangesStatus.Loading)
+    val commitsChangesStatus: StateFlow<MultiCommitChangesStatus> = _commitsChangesStatus
+
+    fun loadChanges(commits: List<RevCommit>) = tabState.runOperation(
+        refreshType = RefreshType.NONE,
+    ) { git ->
+        delayedStateChange(
+            delayMs = MIN_TIME_IN_MS_TO_SHOW_LOAD,
+            onDelayTriggered = { _commitsChangesStatus.value = MultiCommitChangesStatus.Loading }
+        ) {
+            val changes = commits
+                .map { commit ->
+                    CommitChanges(
+                        commit = commit,
+                        changes = getCommitDiffEntriesUseCase(git, commit)
+                    )
+                }
+
+            _commitsChangesStatus.value = MultiCommitChangesStatus.Loaded(changes)
+        }
+    }
+}
+
+sealed class MultiCommitChangesStatus {
+    object Loading : MultiCommitChangesStatus()
+    data class Loaded(val changesList: List<CommitChanges>) : MultiCommitChangesStatus()
+}
+
+data class CommitChanges(
+    val commit: RevCommit,
+    val changes: List<DiffEntry>,
+)

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SquashCommitsViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SquashCommitsViewModel.kt
@@ -1,0 +1,94 @@
+package com.jetpackduba.gitnuro.viewmodels
+
+import com.jetpackduba.gitnuro.git.RefreshType
+import com.jetpackduba.gitnuro.git.TabState
+import com.jetpackduba.gitnuro.git.branches.GetBranchByCommitUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.eclipse.jgit.lib.RebaseTodoLine
+import org.eclipse.jgit.revwalk.RevCommit
+import javax.inject.Inject
+
+class SquashCommitsViewModel @Inject constructor(
+    private val tabState: TabState,
+    private val rebaseInteractiveViewModel: RebaseInteractiveViewModel,
+    private val getBranchByCommitUseCase: GetBranchByCommitUseCase,
+) {
+    private val _squashState = MutableStateFlow<SquashCommitsState>(SquashCommitsState.Loading)
+    val squashState: StateFlow<SquashCommitsState> = _squashState
+
+    private var commits: List<RevCommit> = emptyList()
+    private var squashMessage: String? = null
+
+    init {
+        tabState.runOperation(
+            refreshType = RefreshType.NONE
+        ) {
+            rebaseInteractiveViewModel.rebaseState.collect { state ->
+                _squashState.value = when (state) {
+                    is RebaseInteractiveState.Failed -> SquashCommitsState.Failed(state.error)
+                    is RebaseInteractiveState.Loading -> SquashCommitsState.Loading
+                    is RebaseInteractiveState.Loaded -> {
+                        SquashCommitsState.Loaded(
+                            message = getDefaultSquashMessageFromCommits(
+                                messages = commits.mapNotNull { state.messages[it.abbreviate(7).name()] }
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    suspend fun startSquash(commits: List<RevCommit>, upstreamCommit: RevCommit) = tabState.runOperation(
+        refreshType = RefreshType.ALL_DATA,
+        showError = true,
+    ) { git ->
+        commits
+            .groupBy { getBranchByCommitUseCase(git, it) }
+            .let {
+                if (it.size > 1) throw Exception("Squash is impossible")
+            }
+
+        this.commits = commits
+
+        rebaseInteractiveViewModel.startRebaseInteractive(upstreamCommit)
+    }
+
+    fun cancel() {
+        rebaseInteractiveViewModel.cancel()
+    }
+
+    fun editMessage(message: String) {
+        val state = _squashState.value
+        if (state !is SquashCommitsState.Loaded) return
+        _squashState.value = state.copy(message = message)
+        squashMessage = message
+    }
+
+    fun continueSquash() {
+        commits.forEachIndexed { index, commit ->
+            val abbreviate = commit.abbreviate(7)
+            val action = if (index == commits.size - 1) RebaseTodoLine.Action.PICK else RebaseTodoLine.Action.SQUASH
+            rebaseInteractiveViewModel.onCommitActionChanged(abbreviate, action)
+        }
+
+        rebaseInteractiveViewModel.continueRebaseInteractive()
+    }
+
+    private fun getDefaultSquashMessageFromCommits(messages: List<String>): String = buildString {
+        messages.forEachIndexed { index, value ->
+            append(value)
+            if (messages.size != index + 1) {
+                append("\n")
+            }
+        }
+    }
+
+}
+
+sealed interface SquashCommitsState {
+    object Loading : SquashCommitsState
+    data class Loaded(val message: String) : SquashCommitsState
+    data class Failed(val error: String) : SquashCommitsState
+}

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/TabViewModelsHolder.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/TabViewModelsHolder.kt
@@ -15,6 +15,7 @@ class TabViewModelsHolder @Inject constructor(
     stashesViewModel: StashesViewModel,
     submodulesViewModel: SubmodulesViewModel,
     commitChangesViewModel: CommitChangesViewModel,
+    multiCommitChangesViewModel: MultiCommitChangesViewModel,
     cloneViewModel: CloneViewModel,
     settingsViewModel: SettingsViewModel,
     // Dynamic VM
@@ -33,6 +34,7 @@ class TabViewModelsHolder @Inject constructor(
         stashesViewModel::class to stashesViewModel,
         submodulesViewModel::class to submodulesViewModel,
         commitChangesViewModel::class to commitChangesViewModel,
+        multiCommitChangesViewModel::class to multiCommitChangesViewModel,
         cloneViewModel::class to cloneViewModel,
         settingsViewModel::class to settingsViewModel,
     )

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/TabViewModelsHolder.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/TabViewModelsHolder.kt
@@ -21,6 +21,7 @@ class TabViewModelsHolder @Inject constructor(
     // Dynamic VM
     private val diffViewModelProvider: Provider<DiffViewModel>,
     private val rebaseInteractiveViewModelProvider: Provider<RebaseInteractiveViewModel>,
+    private val squashCommitsViewModel: Provider<SquashCommitsViewModel>,
     private val historyViewModelProvider: Provider<HistoryViewModel>,
     private val authorViewModelProvider: Provider<AuthorViewModel>,
 ) {

--- a/src/test/kotlin/com/jetpackduba/gitnuro/app/git/BeforeRepoAllTestsExtension.kt
+++ b/src/test/kotlin/com/jetpackduba/gitnuro/app/git/BeforeRepoAllTestsExtension.kt
@@ -4,6 +4,7 @@ import com.jetpackduba.gitnuro.credentials.*
 import com.jetpackduba.gitnuro.di.factories.HttpCredentialsFactory
 import com.jetpackduba.gitnuro.git.remote_operations.CloneRepositoryUseCase
 import com.jetpackduba.gitnuro.git.remote_operations.HandleTransportUseCase
+import com.jetpackduba.gitnuro.ssh.libssh.LibSshSession
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.runBlocking
@@ -36,7 +37,13 @@ class BeforeRepoAllTestsExtension : BeforeAllCallback, AfterAllCallback {
             val cloneRepositoryUseCase =
                 CloneRepositoryUseCase(
                     HandleTransportUseCase(
-                        sessionManager = GSessionManager { GRemoteSession({ GProcess() }, credentialsStateManager) },
+                        sessionManager = GSessionManager {
+                            GRemoteSession(
+                                processProvider = { GProcess() },
+                                credentialsStateManager = credentialsStateManager,
+                                processSession = { LibSshSession() }
+                            )
+                        },
                         httpCredentialsProvider = object : HttpCredentialsFactory {
                             override fun create(git: Git?): HttpCredentialsProvider =
                                 HttpCredentialsProvider(credentialsStateManager, git)


### PR DESCRIPTION
This is just a draft. For now, I can’t continue developing, but I’ll be back in a couple of days. If you want, you can look at the original version, but keep in mind that the code is not final.
- you can select multiple commits with Ctrl or Shift
- squash them and change message for the final commit

I have not yet tested how the multi select works with the rest of the options.