### PR TITLE
Documentations/issue 144 Add note about unsupported default JDK

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,8 @@ If you don't have another preference, the recommendation is to download and inst
 [Compose Multiplatform IDE Support](https://plugins.jetbrains.com/plugin/16541-compose-multiplatform-ide-support)
 plugin.
 
+By default, the JDK used by "IntelliJ IDEA Community Edition (2023.1.3)" is "JetBrains Runtime version 21" which is not currently supported by the project.
+
 ## Alternative: Setting up JDK for use on CLI
 
 You don't need this if you only use the JDK installed by IntelliJ IDEA.


### PR DESCRIPTION
Added a note into "Setting up an IDE" about not supporting "JetBrains Runtime 21" yet, since it is the JDK installed by "IntelliJ IDEA Community Edition (2023.1.3)" when there is no JDK installed and there is no ".idea" project folder.

Closes #144