### PR TITLE
Restore selected tabs by index instead of by path

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
@@ -131,10 +131,10 @@ class AppSettingsRepository @Inject constructor() {
             preferences.put(PREF_LATEST_REPOSITORIES_TABS_OPENED, value)
         }
 
-    var latestRepositoryTabSelected: String
-        get() = preferences.get(PREF_LATEST_REPOSITORY_TAB_SELECTED, "")
+    var latestRepositoryTabSelected: Int
+        get() = preferences.getInt(PREF_LATEST_REPOSITORY_TAB_SELECTED, -1)
         set(value) {
-            preferences.put(PREF_LATEST_REPOSITORY_TAB_SELECTED, value)
+            preferences.putInt(PREF_LATEST_REPOSITORY_TAB_SELECTED, value)
         }
 
     var latestOpenedRepositoriesPath: String


### PR DESCRIPTION
This patch switches the "latestRepositoryTabSelected" preference key from a String to an Int value, so the correct tab can be restored with that information.

I noticed that when multiple tabs with the same repository are open, only the first tab with the same repository path is selected when the tabs get restored after a restart of Gitnuro and because you mentioned in [this discussion](https://github.com/JetpackDuba/Gitnuro/issues/197#issuecomment-1898372904) that having multiple tabs open for the same repo is
> something kinda intentional because under some circumastances having a repo opened twice can be useful.

So I gave it a shot. Note that because of the type conversion, the first time Gitnuro is started again, the first tab will always be the selected one regardless of the saved preference. After that, everything should work.