### PR TITLE
Mitigate race condition in network caching

### DIFF
--- a/src/main/kotlin/com/jetpackduba/gitnuro/images/InMemoryImagesCache.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/images/InMemoryImagesCache.kt
@@ -1,5 +1,7 @@
 package com.jetpackduba.gitnuro.images
 
+import com.jetpackduba.gitnuro.logging.printError
+
 object InMemoryImagesCache : ImagesCache {
     private val cachedImages = hashMapOf<String, ByteArray>()
 
@@ -8,6 +10,9 @@ object InMemoryImagesCache : ImagesCache {
     }
 
     override fun cacheImage(urlSource: String, image: ByteArray) {
+        if (cachedImages[urlSource] != null) {
+            printError("CACHE", "Race condition! Image for $urlSource was already in cache")
+        }
         cachedImages[urlSource] = image
     }
 }

--- a/src/main/kotlin/com/jetpackduba/gitnuro/images/NetworkImageLoader.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/images/NetworkImageLoader.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.res.useResource
 import com.jetpackduba.gitnuro.extensions.acquireAndUse
 import com.jetpackduba.gitnuro.extensions.toByteArray
+import com.jetpackduba.gitnuro.logging.printLog
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
@@ -51,6 +52,10 @@ object NetworkImageLoader {
     }
 
     suspend fun loadImage(link: String): ByteArray = withContext(Dispatchers.IO) {
+        // Network access can be considered somewhat surprising for a repository-browser
+        // Don't be shy about admitting the work we do.
+        printLog("NET", "loading image from $link")
+
         val url = URL(link)
         val connection = url.openConnection() as HttpURLConnection
         connection.connect()


### PR DESCRIPTION
Hey, you may remember me from #291 

Gitnuro is still fascinating me.
I've since downloaded the sourcecode to have a go at the AvatarProviders. 
I really like the refactoring you did since the original "useGravatar" boolean. Good job! 

While toying with it, I noticed the gravatar provider does multiple network requests, for the same images, which surprised me, given the InMemoryCache. 

I've documented my findings in the commits.
Tldr: the NetworkImageLoader can trigger multiple times for the same url/image, if a series of commits, by the same author, is processed before the first image is finished loading from the web. 

It's bed time for me now but I'll check back tomorrow.