### PR TITLE
feat: Settings: Add Environment section with default clone directory

### DIFF
--- a/src/main/composeResources/values/strings.xml
+++ b/src/main/composeResources/values/strings.xml
@@ -149,7 +149,7 @@
     <!-- Tag context menu -->
     <string name="tag_context_menu_checkout_tag_commit">Checkout tag's commit</string>
     <string name="tag_context_menu_delete_tag">Delete tag</string>
-  
+
     <!-- Settings -->
     <string name="settings_environment_default_clone_directory_title">Default clone directory</string>
     <string name="settings_environment_default_clone_directory_description">Directory that will be used as default when cloning a repository</string>

--- a/src/main/composeResources/values/strings.xml
+++ b/src/main/composeResources/values/strings.xml
@@ -4,6 +4,7 @@
     <!-- Generic -->
     <string name="generic_button_ok">OK</string>
     <string name="generic_button_cancel">Cancel</string>
+    <string name="generic_save_as_default">Save as default</string>
 
     <!-- Home page -->
     <string name="home_button_open_repository">Open a repository</string>
@@ -81,4 +82,8 @@
     <!-- Merge automatic stash -->
     <string name="merge_automatic_stash_description">Automatic stash before merge of "%1$s" to "%2$s"</string>
     <string name="pull_with_merge_automatic_stash_description">Automatic stash before pull of "%1$s"</string>
+
+    <!-- Settings -->
+    <string name="settings_environment_default_clone_directory_title">Default clone directory</string>
+    <string name="settings_environment_default_clone_directory_description">Directory that will be used as default when cloning a repository</string>
 </resources>

--- a/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/repositories/AppSettingsRepository.kt
@@ -53,6 +53,7 @@ private const val PREF_CACHE_CREDENTIALS_IN_MEMORY = "credentialsInMemory"
 private const val PREF_FIRST_PANE_WIDTH = "firstPaneWidth"
 private const val PREF_THIRD_PANE_WIDTH = "thirdPaneWidth"
 
+private const val PREF_GIT_DEFAULT_CLONE_DIR = "gitDefaultCloneDir"
 private const val PREF_GIT_FF_MERGE = "gitFFMerge"
 private const val PREF_GIT_MERGE_AUTOSTASH = "mergeAutoStash"
 private const val PREF_GIT_PULL_REBASE = "gitPullRebase"
@@ -89,6 +90,9 @@ class AppSettingsRepository @Inject constructor() {
 
     private val _verifySslFlow = MutableStateFlow(cacheCredentialsInMemory)
     val verifySslFlow = _verifySslFlow.asStateFlow()
+
+    private val _defaultCloneDirFlow = MutableStateFlow(defaultCloneDir)
+    val defaultCloneDirFlow = _defaultCloneDirFlow.asStateFlow()
 
     private val _ffMergeFlow = MutableStateFlow(ffMerge)
     val ffMergeFlow = _ffMergeFlow.asStateFlow()
@@ -244,6 +248,17 @@ class AppSettingsRepository @Inject constructor() {
         set(value) {
             preferences.putFloat(PREF_UI_SCALE, value)
             _scaleUiFlow.value = value
+        }
+
+    /*
+     * Property that holds the default directory to clone a repository into.
+     */
+    var defaultCloneDir: String
+        get() = preferences.get(PREF_GIT_DEFAULT_CLONE_DIR, "")
+        set(value) {
+            preferences.put(PREF_GIT_DEFAULT_CLONE_DIR, value)
+
+            _defaultCloneDirFlow.value = value
         }
 
     /**

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/CloneDialog.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/CloneDialog.kt
@@ -97,6 +97,7 @@ private fun CloneDialogView(
     onCloneSubmodulesChange: (Boolean) -> Unit,
 ) {
     val error by cloneViewModel.error.collectAsState()
+    val saveDirAsDefault by cloneViewModel.saveDirAsDefault.collectAsState()
 
     val urlFocusRequester = remember { FocusRequester() }
     val directoryFocusRequester = remember { FocusRequester() }
@@ -181,6 +182,34 @@ private fun CloneDialogView(
                 }
             }
         )
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.handMouseClickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+            ) {
+                cloneViewModel.onSaveAsDefaultChanged(!saveDirAsDefault)
+            }
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+        ) {
+            Checkbox(
+                checked = saveDirAsDefault,
+                onCheckedChange = {
+                    cloneViewModel.onSaveAsDefaultChanged(!saveDirAsDefault)
+                },
+                modifier = Modifier
+                    .padding(all = 8.dp)
+                    .size(12.dp)
+            )
+
+            Text(
+                "Save as Default",
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onBackground,
+            )
+        }
 
         TextInput(
             modifier = Modifier.padding(top = 16.dp),

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/CloneDialog.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/CloneDialog.kt
@@ -21,14 +21,18 @@ import androidx.compose.ui.unit.dp
 import com.jetpackduba.gitnuro.extensions.handMouseClickable
 import com.jetpackduba.gitnuro.extensions.handOnHover
 import com.jetpackduba.gitnuro.generated.resources.Res
+import com.jetpackduba.gitnuro.generated.resources.generic_save_as_default
+import com.jetpackduba.gitnuro.generated.resources.menu_open
 import com.jetpackduba.gitnuro.generated.resources.search
 import com.jetpackduba.gitnuro.git.CloneState
 import com.jetpackduba.gitnuro.theme.outlinedTextFieldColors
 import com.jetpackduba.gitnuro.theme.textButtonColors
 import com.jetpackduba.gitnuro.ui.components.AdjustableOutlinedTextField
+import com.jetpackduba.gitnuro.ui.components.CheckboxText
 import com.jetpackduba.gitnuro.ui.components.PrimaryButton
 import com.jetpackduba.gitnuro.viewmodels.CloneViewModel
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import java.io.File
 
 @Composable
@@ -182,34 +186,11 @@ private fun CloneDialogView(
                 }
             }
         )
-
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.handMouseClickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-            ) {
-                cloneViewModel.onSaveAsDefaultChanged(!saveDirAsDefault)
-            }
-                .fillMaxWidth()
-                .padding(top = 16.dp)
-        ) {
-            Checkbox(
-                checked = saveDirAsDefault,
-                onCheckedChange = {
-                    cloneViewModel.onSaveAsDefaultChanged(!saveDirAsDefault)
-                },
-                modifier = Modifier
-                    .padding(all = 8.dp)
-                    .size(12.dp)
-            )
-
-            Text(
-                "Save as Default",
-                style = MaterialTheme.typography.body2,
-                color = MaterialTheme.colors.onBackground,
-            )
-        }
+        CheckboxText(
+            value = saveDirAsDefault,
+            onCheckedChange = { cloneViewModel.onSaveAsDefaultChanged(!saveDirAsDefault) },
+            text = stringResource(Res.string.generic_save_as_default)
+        )
 
         TextInput(
             modifier = Modifier.padding(top = 16.dp),

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
@@ -61,6 +61,7 @@ val settings = listOf(
     SettingsEntry.Entry(Res.drawable.layout, "Layout") { Layout(it) },
     SettingsEntry.Entry(Res.drawable.schedule, "Date/Time") { DateTime(it) },
     SettingsEntry.Section("GIT"),
+    SettingsEntry.Entry(Res.drawable.folder, "Environment") { Environment(it) },
     SettingsEntry.Entry(Res.drawable.branch, "Branches") { Branches(it) },
     SettingsEntry.Entry(Res.drawable.cloud, "Remote actions") { RemoteActions(it) },
 
@@ -382,6 +383,21 @@ fun Logs(settingsViewModel: SettingsViewModel) {
     )
 }
 
+
+@Composable
+private fun Environment(settingsViewModel: SettingsViewModel) {
+    var defaultCloneDir by remember { mutableStateOf(settingsViewModel.defaultCloneDir) }
+
+    SettingTextInput(
+        title = "Default Clone Directory",
+        subtitle = "Directory that will be used as default when cloning a repository",
+        value = defaultCloneDir,
+        onValueChanged = { value ->
+            defaultCloneDir = value
+            settingsViewModel.defaultCloneDir = value
+        },
+    )
+}
 
 @Composable
 private fun Branches(settingsViewModel: SettingsViewModel) {

--- a/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/ui/dialogs/settings/SettingsDialog.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import java.time.Instant
 
 sealed interface SettingsEntry {
@@ -389,8 +390,8 @@ private fun Environment(settingsViewModel: SettingsViewModel) {
     var defaultCloneDir by remember { mutableStateOf(settingsViewModel.defaultCloneDir) }
 
     SettingTextInput(
-        title = "Default Clone Directory",
-        subtitle = "Directory that will be used as default when cloning a repository",
+        title = stringResource(Res.string.settings_environment_default_clone_directory_title),
+        subtitle = stringResource(Res.string.settings_environment_default_clone_directory_description),
         value = defaultCloneDir,
         onValueChanged = { value ->
             defaultCloneDir = value

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/CloneViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/CloneViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.jetpackduba.gitnuro.git.CloneState
 import com.jetpackduba.gitnuro.git.TabState
 import com.jetpackduba.gitnuro.git.remote_operations.CloneRepositoryUseCase
+import com.jetpackduba.gitnuro.repositories.AppSettingsRepository
 import com.jetpackduba.gitnuro.system.OpenFilePickerUseCase
 import com.jetpackduba.gitnuro.system.PickerType
 import kotlinx.coroutines.Dispatchers
@@ -19,12 +20,16 @@ class CloneViewModel @Inject constructor(
     private val tabState: TabState,
     private val cloneRepositoryUseCase: CloneRepositoryUseCase,
     private val openFilePickerUseCase: OpenFilePickerUseCase,
+    private val appSettingsRepository: AppSettingsRepository,
 ) {
     private val _repositoryUrl = MutableStateFlow(TextFieldValue(""))
     val repositoryUrl = _repositoryUrl.asStateFlow()
 
-    private val _directoryPath = MutableStateFlow(TextFieldValue(""))
+    private val _directoryPath = MutableStateFlow(TextFieldValue(appSettingsRepository.defaultCloneDir))
     val directoryPath = _directoryPath.asStateFlow()
+
+    private val _saveDirAsDefault = MutableStateFlow(false)
+    val saveDirAsDefault = _saveDirAsDefault.asStateFlow()
 
     private val _folder = MutableStateFlow(TextFieldValue(""))
     val folder = _folder.asStateFlow()
@@ -58,6 +63,9 @@ class CloneViewModel @Inject constructor(
 
             if (!directory.exists()) {
                 directory.mkdirs()
+            }
+            if (_saveDirAsDefault.value) {
+                appSettingsRepository.defaultCloneDir = directoryPath
             }
 
             val repoDir = File(directory, folder)
@@ -106,6 +114,10 @@ class CloneViewModel @Inject constructor(
 
     fun onDirectoryPathChanged(directory: TextFieldValue) {
         _directoryPath.value = directory
+    }
+
+    fun onSaveAsDefaultChanged(value: Boolean) {
+        _saveDirAsDefault.value = value
     }
 
     fun onRepositoryUrlChanged(repositoryUrl: TextFieldValue) {

--- a/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SettingsViewModel.kt
+++ b/src/main/kotlin/com/jetpackduba/gitnuro/viewmodels/SettingsViewModel.kt
@@ -35,6 +35,7 @@ class SettingsViewModel @Inject constructor(
 
     val themeState = appSettingsRepository.themeState
     val linesHeightTypeState = appSettingsRepository.linesHeightTypeState
+    var defaultCloneDirFlow = appSettingsRepository.defaultCloneDirFlow
     val ffMergeFlow = appSettingsRepository.ffMergeFlow
     val mergeAutoStashFlow = appSettingsRepository.mergeAutoStashFlow
     val pullRebaseFlow = appSettingsRepository.pullRebaseFlow
@@ -51,6 +52,12 @@ class SettingsViewModel @Inject constructor(
         get() = appSettingsRepository.scaleUi
         set(value) {
             appSettingsRepository.scaleUi = value
+        }
+
+    var defaultCloneDir: String
+        get() = appSettingsRepository.defaultCloneDir
+        set(value) {
+            appSettingsRepository.defaultCloneDir = value
         }
 
     var swapUncommittedChanges: Boolean


### PR DESCRIPTION
Based on request #261 , a new setting (with section _"Environment"_ ) is introduced.
When the clone repository dialog is opened, the settings is read.
The clonerepository dialog contains a checkbox to allow overwriting the setting from the dialog.

![grafik](https://github.com/user-attachments/assets/2b821061-bbed-4b4d-8d3d-0a47a5ebae97)

![grafik](https://github.com/user-attachments/assets/672c267c-af83-4e68-ad98-c87ead820e86)

Since this is my first touch with Kotlin, please always ELI5 :) 
